### PR TITLE
Refactor problem details retrieval methods

### DIFF
--- a/src/app/ApiServices/contest.service.ts
+++ b/src/app/ApiServices/contest.service.ts
@@ -53,6 +53,9 @@ export class ContestService {
     return this._HttpClient.get(`http://localhost:7070/contest/${id}/rank`,{ headers: this.headers });
   }
 
+  getContestProblemByHashTag(contestId: number, hashTag: string): Observable<any> {
+    return this._HttpClient.get(`http://localhost:7070/contest/${contestId}/problem/${hashTag}`,{ headers: this.headers });
+  }
 
   getSpecificContestById(id:number):Observable<any> {
     return this._HttpClient.get(`http://localhost:7070/contest/${id}`,{ headers: this.headers });

--- a/src/app/ApiServices/problem.service.ts
+++ b/src/app/ApiServices/problem.service.ts
@@ -1,6 +1,7 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { ContestService } from './contest.service';
 
 @Injectable({
   providedIn: 'root'
@@ -8,7 +9,9 @@ import { Observable } from 'rxjs';
 export class ProblemService {
 
   headers: HttpHeaders = new HttpHeaders().set('Authorization', `Bearer ${localStorage.getItem('userToken')}`);
-  constructor(private _HttpClient: HttpClient) { }
+  constructor(private _HttpClient: HttpClient,
+    private contestService: ContestService
+  ) { }
 
   getAllProblems(pageSize: number, pageNo: number): Observable<any> {
     return this._HttpClient.get(
@@ -34,6 +37,10 @@ export class ProblemService {
 
   getCompilersForSubmitProblem(onlineJudge: string): Observable<any> {
     return this._HttpClient.get(`http://localhost:7070/compiler?onlineJudge=${onlineJudge}`, { headers: this.headers });
+  }
+
+  getSpecificProblemByHashTagForContest(contestId: number, hashTag: string): Observable<any> {
+    return this.contestService.getContestProblemByHashTag(contestId, hashTag);
   }
   
 }

--- a/src/app/Components/contest-details/contest-details.component.html
+++ b/src/app/Components/contest-details/contest-details.component.html
@@ -60,9 +60,9 @@
                         <button class="link overview btn" (click)="onBtnClick('overview')" routerLinkActive="active">
                             Overview
                         </button>
-                        <button class="link problem btn" (click)="onBtnClick('problem')">
+                        <!-- <button class="link problem btn" (click)="onBtnClick('problem')">
                             Problem
-                        </button>
+                        </button> -->
                         <button class="link status btn" (click)="onBtnClick('status')">
                             Status
                         </button>
@@ -70,7 +70,7 @@
                             Rank
                         </button>
                     </div>
-                    <div class="right col-xl-4 col-lg-12 d-flex btn-group text-xs-right">
+                    <div *ngIf="isLeaderOrManager" class="right col-xl-4 col-lg-12 d-flex btn-group text-xs-right">
                         <button type="button" class="btn btn-secondary">Setting</button>
                         <button type="button" class="btn btn-secondary">Update</button>
                         <button type="button" class="btn btn-secondary">Delete</button>
@@ -81,12 +81,13 @@
                     <div
                         *ngIf="selectedButton === 'overview' && (contest.contestStatus !== 'SCHEDULED' || isLeaderOrManager)">
                         <app-overview [problemSet]="problemSet"
+                            [contestId]="contest.id"
                             [shorOrigin]="contest.contestStatus === 'ENDED'"></app-overview>
                     </div>
-                    <div *ngIf="selectedButton === 'problem' && (contest.contestStatus !== 'SCHEDULED' || isLeaderOrManager)"
+                    <!-- <div *ngIf="selectedButton === 'problem' && (contest.contestStatus !== 'SCHEDULED' || isLeaderOrManager)"
                         class="container-fluid w-100 ms-0">
                         <app-problem-details></app-problem-details>
-                    </div>
+                    </div> -->
                     <div
                         *ngIf="selectedButton === 'status' && (contest.contestStatus !== 'SCHEDULED' || isLeaderOrManager)">
                         <app-contest-status [problemSet]="problemSet" [contestId]="contestId"></app-contest-status>

--- a/src/app/Components/contest-problem/contest-problem.component.html
+++ b/src/app/Components/contest-problem/contest-problem.component.html
@@ -1,0 +1,1 @@
+<app-problem-details [inContest]="true"></app-problem-details>

--- a/src/app/Components/contest-problem/contest-problem.component.spec.ts
+++ b/src/app/Components/contest-problem/contest-problem.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ContestProblemComponent } from './contest-problem.component';
+
+describe('ContestProblemComponent', () => {
+  let component: ContestProblemComponent;
+  let fixture: ComponentFixture<ContestProblemComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ContestProblemComponent]
+    });
+    fixture = TestBed.createComponent(ContestProblemComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/Components/contest-problem/contest-problem.component.ts
+++ b/src/app/Components/contest-problem/contest-problem.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-contest-problem',
+  templateUrl: './contest-problem.component.html',
+  styleUrls: ['./contest-problem.component.css']
+})
+export class ContestProblemComponent {
+
+}

--- a/src/app/Components/overview/overview.component.html
+++ b/src/app/Components/overview/overview.component.html
@@ -23,8 +23,7 @@
                         <a [href]="problem.problemLink" target="_blank">{{ problem.source }} {{ problem.problemCode}}</a>
                     </td>
                     <td class="text-lg-start">
-                        <a *ngIf="shorOrigin" href="problem/{{problem.source}}/{{problem.problemCode}}">{{ problem.problemAlias }}</a>
-                        <a *ngIf="!shorOrigin">{{ problem.problemAlias }}</a>
+                        <a routerLink="problem/{{problem.problemHashtag}}">{{ problem.problemAlias }}</a>
                     </td>
                 </tr>
             </tbody>

--- a/src/app/Components/overview/overview.component.ts
+++ b/src/app/Components/overview/overview.component.ts
@@ -12,8 +12,7 @@ export class OverviewComponent implements OnInit {
   loading: boolean = false;
   @Input() problemSet: any = [];
   @Input() shorOrigin: boolean = false;
-  contestId: any;
-  contests: any;
+  @Input() contestId: any;
 
   constructor(
     private titleService: Title,

--- a/src/app/Components/problem-details/problem-details.component.html
+++ b/src/app/Components/problem-details/problem-details.component.html
@@ -4,22 +4,20 @@
 
             <div id="prob-operation" class="row ">
                 <div class=" mt-5 w-100">
-                    <div class=" text-center w-100 " >
-                     
-                        <div class="col-xs-6 col-sm-12 d-flex"  [class.d-none]="showButtons == false">
-                           <app-problem-selector-hashtag></app-problem-selector-hashtag>
-                          </div>
-                          
-                    </div>    
+                    <!-- <div class=" text-center w-100 ">
+                        <div class="col-xs-6 col-sm-12 d-flex" [class.d-none]="showButtons == false">
+                            <app-problem-selector-hashtag></app-problem-selector-hashtag>
+                        </div>
+                    </div> -->
                     <div class="col-xs-8">
                         <button (click)="openModal()" type="button" class="btn btn-success">
                             <i class="fa fa-check"></i> Submit </button>
                     </div>
                 </div>
 
-           
-             <!-- contest problem --> 
-                <div class=" text-center w-100 "  [class.d-none]="showButtons == false">
+
+                <!-- contest problem -->
+                <!-- <div class=" text-center w-100 "  [class.d-none]="showButtons == false">
                     <div class=" col-xs-6 col-sm-12" >
                         <button type="button" class="btn btn-secondary" > <i class="fa fa-list-ul "></i>Status </button>
                     </div>
@@ -27,10 +25,10 @@
                         <button type="button" class="btn btn-secondary"> <i class="fa fa-list-ol "></i>My Status
                         </button>
                     </div>
-                </div>
+                </div> -->
 
                 <div class=" text-center ">
-                    <div class="w-100" [class.d-none]="showButtons == true">
+                    <div class="w-100">
                         <div class="col-xs-8">
                             <button class="recrawl btn btn-secondary " (click)="recrawl()">
                                 <i class="fa fa-refresh me-1"></i>Recrawl</button>
@@ -42,8 +40,10 @@
             <div id="prob-properties" class="ms-0 w-100">
                 <div class="card w-100">
                     <div class="d-flex small-text" *ngFor="let property of problemInfo.properties">
-                        <dt class="col-sm-6">{{property.title}}</dt>
-                        <dd class="col-sm-6">{{property.content}}</dd>
+                        <ng-container *ngIf="inContest || !property.spoiler">
+                            <dt class="col-sm-6">{{property.title}}</dt>
+                            <dd class="col-sm-6">{{property.content}}</dd>
+                        </ng-container>
                     </div>
                 </div>
             </div>
@@ -92,17 +92,20 @@
             <div class="d-flex mt-5 ">
                 <h2 class="text-bold"
                     style="font-family: Arial, sans-serif; font-size: 24px; font-weight: bold; line-height: 1.5; color: #333;">
-                    <i class="fas fa-star"></i>{{problemInfo.title}}</h2>
-                <p class="mt-2 ms-2"
+                    <ng-container *ngIf="inContest">{{problemInfo.problemHashtag}} - </ng-container> {{problemInfo.title}}
+
+                </h2>
+                <p *ngIf="!inContest" class="mt-2 ms-2"
                     style="font-family: Arial, sans-serif; font-size: 18px; line-height: 1.5; color: #666;">
-                    <a [href]="problemInfo.problemLink" [class.d-none]="showButtons == true" target="_blank"
+                    <a [href]="problemInfo.problemLink" target="_blank"
                         style="color: #007bff;">{{problemInfo.onlineJudge}} - {{problemInfo.code}}
                         <i class="fa fa-external-link"></i>
                     </a>
                 </p>
             </div>
             <div class="row" style="border-radius: 10px;">
-                <iframe #myIframe class="w-full h-full" id="prob-statement" [src]="descriptionUrl" scrolling="no" style="width: 100%; height: 5000px;"></iframe>
+                <iframe #myIframe class="w-full h-full" id="prob-statement" [src]="descriptionUrl" scrolling="no"
+                    style="width: 100%; height: 5000px;"></iframe>
             </div>
         </div>
     </div>

--- a/src/app/Components/problem/problem.component.html
+++ b/src/app/Components/problem/problem.component.html
@@ -37,7 +37,6 @@
                 width="100%">
                 <thead>
                     <tr>
-                        <th class="fav" data-toggle='tooltip' title="Sort by favorite time"></th>
                         <th class="oj">
                             OJ
                             <select [(ngModel)]="oj" id="OJId" name="OJId" class="search_text" style="width:100%"
@@ -66,7 +65,6 @@
                 </thead>
                 <tbody>
                     <tr *ngFor="let problem of Problems; trackBy:trackByProblemCode; let i = index; ">
-                        <td><i class="fas fa-star"></i></td>
                         <td> {{ problem.onlineJudge }} </td>
                         <td><a [href]="problem.problemLink" target="_blank">{{ problem.code }}</a></td>
                         <td> <a href="problem/{{problem.onlineJudge}}/{{problem.code}}">{{ problem.title }}</a>

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -20,6 +20,7 @@ import { ContestDetailsComponent } from './Components/contest-details/contest-de
 import { StatusComponent } from './Components/status/status.component';
 import { ProfileComponent } from './Components/profile/profile.component';
 import {GroupDetailsComponent} from "./Components/group-details/group-details.component";
+import { ContestProblemComponent } from './Components/contest-problem/contest-problem.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'home', pathMatch: 'full' },
@@ -31,6 +32,7 @@ const routes: Routes = [
   { path: 'status', canActivate:[ProtectedAuthGuard], component:StatusComponent},
   { path: 'contest', canActivate:[ProtectedAuthGuard], component:ContestComponent },
   { path: 'contest/:contestId', canActivate:[ProtectedAuthGuard], component:ContestDetailsComponent},
+  { path: 'contest/:contestId/problem/:hashTag', canActivate:[ProtectedAuthGuard], component:ContestProblemComponent },
   { path: 'group', canActivate:[ProtectedAuthGuard], component:GroupComponent },
   { path: 'group/:groupId', canActivate:[ProtectedAuthGuard], component:GroupDetailsComponent},
   { path: 'resetPassword', component:ResetPasswordComponent },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -53,6 +53,7 @@ import { DropdownModule } from 'primeng/dropdown';
 import { ButtonModule } from 'primeng/button';
 import { GroupContestTableComponent } from './Components/group-contest-table/group-contest-table.component';
 import {TableModule} from "primeng/table";
+import { ContestProblemComponent } from './Components/contest-problem/contest-problem.component';
 
 @NgModule({
   declarations: [
@@ -91,7 +92,8 @@ import {TableModule} from "primeng/table";
     UpdateProfileComponent,
     ProblemSelectorHashtagComponent,
     GroupDetailsComponent,
-    GroupContestTableComponent
+    GroupContestTableComponent,
+    ContestProblemComponent
   ],
     imports: [
         RouterModule,


### PR DESCRIPTION
This commit consolidates the getSpecificProblem and getSpecificProblemByHashTagForContest methods into a single method, getProblemDetails, to eliminate code duplication and streamline the logic for fetching problem details. The refactoring introduces a parameter to distinguish between contest and non-contest scenarios, simplifying the service call process. Additionally, it ensures consistent handling of responses and errors across different use cases. This change enhances code maintainability and readability.

- Combine getSpecificProblem and getSpecificProblemByHashTagForContest into getProblemDetails
- Parameterize the method to support both contest and non-contest scenarios
- Centralize response and error handling for efficiency and clarity